### PR TITLE
Add scratch note web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # codex-frontend
+
+A minimal scratch note web app. Open `index.html` in a browser, write thoughts in the text area, and save them. Notes are stored in your browser's local storage and displayed grouped by date and by concept tags (words starting with `#`).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scratch Thoughts</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Scratch Thoughts</h1>
+  <form id="note-form">
+    <textarea id="note-input" placeholder="Write your thoughts here..." required></textarea>
+    <div class="actions">
+      <button type="submit">Save Note</button>
+    </div>
+  </form>
+  <section id="notes-by-date">
+    <h2>Notes by Date</h2>
+  </section>
+  <section id="notes-by-tag">
+    <h2>Notes by Concept</h2>
+  </section>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,93 @@
+const noteForm = document.getElementById('note-form');
+const noteInput = document.getElementById('note-input');
+const notesByDate = document.getElementById('notes-by-date');
+const notesByTag = document.getElementById('notes-by-tag');
+
+function loadNotes() {
+  return JSON.parse(localStorage.getItem('notes') || '[]');
+}
+
+function saveNotes(notes) {
+  localStorage.setItem('notes', JSON.stringify(notes));
+}
+
+function parseTags(text) {
+  const regex = /#(\w+)/g;
+  const tags = new Set();
+  let match;
+  while ((match = regex.exec(text))) {
+    tags.add(match[1].toLowerCase());
+  }
+  return Array.from(tags);
+}
+
+function render() {
+  const notes = loadNotes();
+  renderByDate(notes);
+  renderByTag(notes);
+}
+
+function renderByDate(notes) {
+  notesByDate.innerHTML = '<h2>Notes by Date</h2>';
+  const grouped = {};
+  notes.forEach((note) => {
+    const date = note.date.split('T')[0];
+    if (!grouped[date]) grouped[date] = [];
+    grouped[date].push(note);
+  });
+  Object.keys(grouped)
+    .sort((a, b) => b.localeCompare(a))
+    .forEach((date) => {
+      const div = document.createElement('div');
+      const h3 = document.createElement('h3');
+      h3.textContent = date;
+      div.appendChild(h3);
+      grouped[date].forEach((n) => {
+        const p = document.createElement('div');
+        p.className = 'note';
+        p.textContent = n.content;
+        div.appendChild(p);
+      });
+      notesByDate.appendChild(div);
+    });
+}
+
+function renderByTag(notes) {
+  notesByTag.innerHTML = '<h2>Notes by Concept</h2>';
+  const grouped = {};
+  notes.forEach((note) => {
+    note.tags.forEach((tag) => {
+      if (!grouped[tag]) grouped[tag] = [];
+      grouped[tag].push(note);
+    });
+  });
+  Object.keys(grouped)
+    .sort()
+    .forEach((tag) => {
+      const div = document.createElement('div');
+      const h3 = document.createElement('h3');
+      h3.textContent = tag;
+      div.appendChild(h3);
+      grouped[tag].forEach((n) => {
+        const p = document.createElement('div');
+        p.className = 'note';
+        p.textContent = n.content;
+        div.appendChild(p);
+      });
+      notesByTag.appendChild(div);
+    });
+}
+
+noteForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const content = noteInput.value.trim();
+  if (!content) return;
+  const tags = parseTags(content);
+  const notes = loadNotes();
+  notes.push({ content, date: new Date().toISOString(), tags });
+  saveNotes(notes);
+  noteInput.value = '';
+  render();
+});
+
+render();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,43 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+  background: #f9f9f9;
+  color: #333;
+}
+
+h1 {
+  text-align: center;
+}
+
+form {
+  margin-bottom: 2rem;
+}
+
+#note-input {
+  width: 100%;
+  height: 150px;
+}
+
+.actions {
+  text-align: right;
+}
+
+section {
+  margin-top: 2rem;
+}
+
+.note {
+  background: #fff;
+  padding: 0.5rem;
+  margin: 0.25rem 0;
+  border: 1px solid #ddd;
+}
+
+.tag {
+  display: inline-block;
+  margin-right: 0.5rem;
+  background: #e0e0e0;
+  padding: 0.2rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Summary
- add minimal scratch note website for jotting thoughts, stored locally
- notes grouped by creation date and by extracted #concept tags

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953974df3c83318e0092f9b662672c